### PR TITLE
Serve the old docs from /docs to keep links alive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "static/docs"]
+	path = static/docs
+	url = git@github.com:micrometer-metrics/micrometer-docs.git
+	branch = embedded-docs

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link, HeadFC, PageProps } from "gatsby";
+import { Link, HeadFC, PageProps, Script } from "gatsby";
 
 const pageStyles = {
   color: "#232129",
@@ -24,12 +24,48 @@ const codeStyles = {
 };
 
 const browser = typeof window !== "undefined" && window;
+const isRedirectingDocs : boolean = browser && window.location.pathname.split('/')[1] === 'docs';
 
 const NotFoundPage: React.FC<PageProps> = () => {
   return (
     browser && (
       <main style={pageStyles}>
-        <h1 style={headingStyles}>Page not found</h1>
+        <h1 style={headingStyles}>{ isRedirectingDocs ? 'Redirecting' : 'Page not found' }</h1>
+        <Script id="redirect-docs-script">
+          {`
+            // Single Page Apps for GitHub Pages
+            // MIT License
+            // https://github.com/rafgraph/spa-github-pages
+            // This script takes the current url and converts the path and query
+            // string into just a query string, and then redirects the browser
+            // to the new url with only a query string and hash fragment,
+            // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+            // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+            // Note: this 404.html file must be at least 512 bytes for it to work
+            // with Internet Explorer (it is currently > 512 bytes)
+
+            // If you're creating a Project Pages site and NOT using a custom domain,
+            // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+            // This way the code will only replace the route part of the path, and not
+            // the real directory in which the app resides, for example:
+            // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+            // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+            // Otherwise, leave pathSegmentsToKeep as 0.
+            var pathSegmentsToKeep = 1;
+
+            var l = window.location;
+            if (l.pathname.split('/')[1] === 'docs') {
+              l.replace(
+                l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+                l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+                l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+                (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+                l.hash
+              );
+            }
+          `}
+        </Script>
+        { !isRedirectingDocs ? (
         <p style={paragraphStyles}>
           Sorry 😔, we couldn’t find what you were looking for.
           <br />
@@ -43,6 +79,7 @@ const NotFoundPage: React.FC<PageProps> = () => {
           <br />
           <Link to="/">Go home</Link>.
         </p>
+          ) : null }
       </main>
     )
   );


### PR DESCRIPTION
This points at a (probably) temporary `embedded-docs` branch on the micrometer-docs repo, so we can test this approach and stage it for deployment.

See https://github.com/micrometer-metrics/micrometer-docs/pull/341 which is from where the static site was built that's being brought in via git submodule here.

This can be ran locally with the following commands (you may need to run `yarn clean` before):
```
yarn install
yarn build
yarn serve
```

Then you should have the site running locally on port 9000, and you can access the docs at e.g. http://localhost:9000/docs/

~There is still the issue mentioned at https://github.com/micrometer-metrics/micrometer-docs/pull/341 where trying to directly access somewhere under /docs (for example, /docs/concepts) doesn't work. Clicking on a link to /docs/concepts from /docs would work because it goes through the client-side routing.
We can follow-up with a fix for that after this, I think. This still brings us closer to ready to launch the new site and would allow more testing outside of running this locally if we merge.~