### PR TITLE
Add link to the archived docs site

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -74,6 +74,14 @@ const Nav = ({ isDesktop, subitems, onClickItem }: any) => {
               Micrometer Docs Generator
             </Link>
           </li>
+          <li>
+            <Link
+              className={`${item2Item}`}
+              to="https://micrometer.io/docs/"
+            >
+              Documentation Archive (1.11 and earlier)
+            </Link>
+          </li>
         </ul>
       </div>
       <Link className={`${item2Item}`} to="/support/">


### PR DESCRIPTION
It looks like this:
<img width="636" alt="Screenshot 2024-02-28 at 10 01 25" src="https://github.com/micrometer-metrics/micrometer-website/assets/3044070/21f291df-97ac-467a-896e-b165345797ab">
